### PR TITLE
feat: allow passing options directly (#93)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,24 +1,12 @@
 const glob = require('glob-all')
-const consola = require('consola')
-const logger = consola.withScope('nuxt-style-resources')
 
 export default function nuxtStyledResources(moduleOptions) {
   const resolver = (this.nuxt.resolver || this.nuxt)
 
-  const {
-    styleResources = moduleOptions,
-    build: {
-      styleResources: legacyStyledResources,
-      loaders: { stylus: stylusLoaderOptions }
-    }
-  } = this.options
+  const stylusLoaderOptions = this.options.build.loaders.stylus
+  const options = { ...moduleOptions, ...this.options.build.styleResources, ...this.options.styleResources }
 
-  // A bit messy. Check for truthyness and keys and return
-  const legacyResources = legacyStyledResources && Object.keys(legacyStyledResources).length && legacyStyledResources
-
-  const resources = legacyResources || styleResources
-
-  const styleResourcesEntries = Object.entries(resources)
+  const styleResourcesEntries = Object.entries(options)
 
   if (!styleResourcesEntries.length) {
     // No resources set
@@ -45,11 +33,6 @@ export default function nuxtStyledResources(moduleOptions) {
     }, {})
 
   const { scss = [], sass = [], less = [], stylus = [] } = retrieveStyleArrays(styleResourcesEntries)
-
-  if (legacyResources) {
-    logger.warn('Legacy styleResources detected. Will take over but ignore all other rules. Please move the rules to the top-level styleResources key')
-    this.options.build.styleResources = {}
-  }
 
   if (sass.length) {
     this.extendBuild(extendSass(sass))

--- a/test/fixture/stylus/nuxt.config.js
+++ b/test/fixture/stylus/nuxt.config.js
@@ -7,10 +7,9 @@ module.exports = {
   render: {
     resourceHints: false
   },
-  styleResources: {
-    stylus: ['~assets/variables.styl']
-  },
-  buildModules: ['@@'],
+  buildModules: [
+    ['@@', { stylus: ['~assets/variables.styl'] }]
+  ],
   build: {
     quiet: false,
     optimization: {


### PR DESCRIPTION
This should allow users to pass options directly with the module itself like:

```js
modules: [
  [
    "@nuxtjs/style-resources",
    {
      scss: ["~css/variables.scss"]
    }
  ]
]
```

@manniL I adapted the stylus test case to make sure this is represented in tests too.

The `less` test for `nuxt-next` fails since I removed the condition to either use `legacyResources` or `styleResources` but merged all options together.

So I assume something about `options.build` will change with `nuxt-next`?
Should I add back this condition or do we need to adapt tests in this case?