### PR TITLE
chore(deps): don't define engines to avoid renovate bumping it

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
     "style-resources",
     "import"
   ],
-  "engines": {
-    "node": ">=v10.24.1",
-    "npm": ">=6.14.14"
-  },
   "jest": {
     "testEnvironment": "node",
     "collectCoverage": true,


### PR DESCRIPTION
Bumping it requires that all users run the latest npm version, for
example, which makes no sense for this module to force.

Also removed "node" field as, first of all, the minimum version should
be 12 (to match Nuxt) but then we also wouldn't want to always bump it
to the latest patch version.

Instead of figuring out how to configure Renovate (which has pretty
weak documentation in that area), decided to just remove those fields.

Fixes #178