### PR TITLE
docs: info about sass-loader ver for Nuxt2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use this module only to import variables, mixins, functions (et cetera) as they 
 ## Setup
 
 - If not already present, add the dependencies you need for SASS/LESS/Stylus (depending on your needs)
-  - SASS: `yarn add sass-loader sass`
+  - SASS: `yarn add sass-loader sass` (for Nuxt 2 use: ``sass-loader@10``)
   - LESS: `yarn add less-loader less`
   - Stylus: `yarn add stylus-loader stylus`
 - Add `@nuxtjs/style-resources` dependency using yarn or npm to your project (`yarn add -D @nuxtjs/style-resources`)


### PR DESCRIPTION
Important to inform users that the maximum version for `sass-loader` in Nuxt2 is @10