### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.0.0](https://github.com/nuxt-community/style-resources-module/compare/v1.2.1...v2.0.0) (2023-10-06)
+
+### Features
+
+* Support for Nuxt 3 ([#214](https://github.com/nuxt-community/style-resources-module/pull/214)) ([1dd88cb](https://github.com/nuxt-community/style-resources-module/commit/1dd88cb33d8c0bb08edc836c0766be728020b1e0))
+
 ### [1.2.1](https://github.com/nuxt-community/style-resources-module/compare/v1.2.0...v1.2.1) (2021-08-05)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/style-resources",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
2.0.0 and later support Nuxt 3 only.
Use `@nuxtjs/style-resources@^1` if you want to use it with Nuxt 2.

## 🚀 Features

* Support for Nuxt 3 ([#214](https://github.com/nuxt-community/style-resources-module/pull/214))